### PR TITLE
Ignore invalid values while plotting (issue #11)

### DIFF
--- a/source/ggplotd/aes.d
+++ b/source/ggplotd/aes.d
@@ -676,6 +676,15 @@ unittest
     auto strs = NumericLabel!(string[])(["a", "c", "b", "a"]);
     assertEqual(strs.map!((a) => a[0]).array, [0, 1, 2.0, 0.0]);
     assertEqual(strs.map!((a) => a[1]).array, ["a", "c", "b", "a"]);
+
+
+    // Ignore NaN values
+    num = NumericLabel!(double[])([0.0, double.init, 1.0, 0.0]);
+    assertEqual(num.map!((a) => a[0]).array, [0.0, 1.0, 0.0]);
+    assertEqual(num.map!((a) => a[1]).array, ["0", "1", "0"]);
+    num = NumericLabel!(double[])([0.0, 0.1, 1.0, double.init]);
+    assertEqual(num.map!((a) => a[0]).array, [0.0, 1.0, 0.0]);
+    assertEqual(num.map!((a) => a[1]).array, ["0", "0.1", "1"]);
 }
 
 ///

--- a/source/ggplotd/aes.d
+++ b/source/ggplotd/aes.d
@@ -676,15 +676,6 @@ unittest
     auto strs = NumericLabel!(string[])(["a", "c", "b", "a"]);
     assertEqual(strs.map!((a) => a[0]).array, [0, 1, 2.0, 0.0]);
     assertEqual(strs.map!((a) => a[1]).array, ["a", "c", "b", "a"]);
-
-
-    // Ignore NaN values
-    num = NumericLabel!(double[])([0.0, double.init, 1.0, 0.0]);
-    assertEqual(num.map!((a) => a[0]).array, [0.0, 1.0, 0.0]);
-    assertEqual(num.map!((a) => a[1]).array, ["0", "1", "0"]);
-    num = NumericLabel!(double[])([0.0, 0.1, 1.0, double.init]);
-    assertEqual(num.map!((a) => a[0]).array, [0.0, 1.0, 0.0]);
-    assertEqual(num.map!((a) => a[1]).array, ["0", "0.1", "1"]);
 }
 
 ///

--- a/source/ggplotd/bounds.d
+++ b/source/ggplotd/bounds.d
@@ -267,9 +267,9 @@ Here we take care to always return a valid set of bounds
     /// Adapt bounds to include the new point
     bool adapt(T : Point)(in T point)
     {
-        import std.math : isNaN;
+        import std.math : isFinite;
         bool adapted = false;
-        if (isNaN(point.x) || isNaN(point.y))
+        if (!isFinite(point.x) || !isFinite(point.y))
             return adapted;
 
         if (!valid)
@@ -362,6 +362,11 @@ unittest
     assert(!bounds.adapt(Point(double.init, 1.0)));
     assert(!bounds.adapt(Point(-1.0,double.init)));
     assert(!bounds.adapt(Point(double.init, double.init)));
+
+    import std.math;
+    assert(!bounds.adapt(Point(log(0.0), 1.0)));
+    assert(!bounds.adapt(Point(-1.0,log(0.0))));
+    assert(!bounds.adapt(Point(log(0.0), log(0.0))));
 }
 
 unittest

--- a/source/ggplotd/bounds.d
+++ b/source/ggplotd/bounds.d
@@ -267,7 +267,11 @@ Here we take care to always return a valid set of bounds
     /// Adapt bounds to include the new point
     bool adapt(T : Point)(in T point)
     {
+        import std.math : isNaN;
         bool adapted = false;
+        if (isNaN(point.x) || isNaN(point.y))
+            return adapted;
+
         if (!valid)
         {
             adapted = true;
@@ -353,6 +357,11 @@ unittest
     assert(bounds.valid);
     pnt = Point(4, 4);
     assert(!bounds.adapt(pnt));
+
+
+    assert(!bounds.adapt(Point(double.init, 1.0)));
+    assert(!bounds.adapt(Point(-1.0,double.init)));
+    assert(!bounds.adapt(Point(double.init, double.init)));
 }
 
 unittest

--- a/source/ggplotd/geom.d
+++ b/source/ggplotd/geom.d
@@ -112,6 +112,9 @@ auto geomRectangle(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
+                import std.math : isNaN;
+                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                    return context;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
                 static if (is(typeof(tup.width)==immutable(Pixel)))
@@ -202,6 +205,9 @@ auto geomEllipse(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
+                import std.math : isNaN;
+                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                    return context;
                 import std.math : PI;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
@@ -288,6 +294,9 @@ auto geomTriangle(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
+                import std.math : isNaN;
+                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                    return context;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
                 static if (is(typeof(tup.width)==immutable(Pixel)))
@@ -376,6 +385,9 @@ auto geomDiamond(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
+                import std.math : isNaN;
+                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                    return context;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
                 static if (is(typeof(tup.width)==immutable(Pixel)))
@@ -477,13 +489,19 @@ auto geomLine(AES)(AES aes)
 
             immutable flags = groupedAes.front.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) {
+
+                import std.math : isNaN;
                 auto fr = coords.front;
                 context.moveTo(fr[0][0], fr[1][0]);
                 coords.popFront;
                 foreach (tup; coords)
                 {
-                    context.lineTo(tup[0][0], tup[1][0]);
-                    context.lineWidth = 2.0*flags.size;
+                    // TODO should we actually move to next coordinate here?
+                    if (!isNaN(tup[0][0]) && !isNaN(tup[1][0]))
+                    {
+                        context.lineTo(tup[0][0], tup[1][0]);
+                        context.lineWidth = 2.0*flags.size;
+                    }
                 }
 
                 auto col = colourMap(ColourID(flags.colour));
@@ -900,6 +918,9 @@ auto geomLabel(AES)(AES aes)
         {
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap) {
+                import std.math : isNaN;
+                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                    return context;
                 context.setFontSize(14.0*tup.size);
                 context.moveTo(tup.x[0], tup.y[0]);
                 context.save();

--- a/source/ggplotd/geom.d
+++ b/source/ggplotd/geom.d
@@ -112,8 +112,8 @@ auto geomRectangle(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
-                import std.math : isNaN;
-                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                import std.math : isFinite;
+                if (!isFinite(tup.x[0]) || !isFinite(tup.y[0]))
                     return context;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
@@ -205,8 +205,8 @@ auto geomEllipse(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
-                import std.math : isNaN;
-                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                import std.math : isFinite;
+                if (!isFinite(tup.x[0]) || !isFinite(tup.y[0]))
                     return context;
                 import std.math : PI;
                 context.save();
@@ -294,8 +294,8 @@ auto geomTriangle(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
-                import std.math : isNaN;
-                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                import std.math : isFinite;
+                if (!isFinite(tup.x[0]) || !isFinite(tup.y[0]))
                     return context;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
@@ -385,8 +385,8 @@ auto geomDiamond(AES)(AES aes)
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) 
             {
-                import std.math : isNaN;
-                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                import std.math : isFinite;
+                if (!isFinite(tup.x[0]) || !isFinite(tup.y[0]))
                     return context;
                 context.save();
                 context.translate( tup.x[0], tup.y[0] );
@@ -490,17 +490,19 @@ auto geomLine(AES)(AES aes)
             immutable flags = groupedAes.front.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap ) {
 
-                import std.math : isNaN;
+                import std.math : isFinite;
                 auto fr = coords.front;
                 context.moveTo(fr[0][0], fr[1][0]);
                 coords.popFront;
                 foreach (tup; coords)
                 {
                     // TODO should we actually move to next coordinate here?
-                    if (!isNaN(tup[0][0]) && !isNaN(tup[1][0]))
+                    if (isFinite(tup[0][0]) && isFinite(tup[1][0]))
                     {
                         context.lineTo(tup[0][0], tup[1][0]);
                         context.lineWidth = 2.0*flags.size;
+                    } else {
+                        context.newSubPath();
                     }
                 }
 
@@ -918,8 +920,8 @@ auto geomLabel(AES)(AES aes)
         {
             immutable tup = _aes.front;
             immutable f = delegate(cairo.Context context, ColourMap colourMap) {
-                import std.math : isNaN;
-                if (isNaN(tup.x[0]) || isNaN(tup.y[0]))
+                import std.math : isFinite;
+                if (!isFinite(tup.x[0]) || !isFinite(tup.y[0]))
                     return context;
                 context.setFontSize(14.0*tup.size);
                 context.moveTo(tup.x[0], tup.y[0]);

--- a/source/ggplotd/range.d
+++ b/source/ggplotd/range.d
@@ -49,6 +49,7 @@ auto uniquer(R)(R range)
             import std.range : front, popFront, empty;
             while( !range.empty )
             {
+                // TODO: Currently this causes an unnecessary "initial" check, because we now that previous value was already added. I think the only way to solve this would be to keep currentValue and possible future value around.
                 if (set.put(range.front))
                 {
                     currentFront = range.front;


### PR DESCRIPTION
- [x] Ignore NaN values when plotting
- [x] geomLine should break on NaN values (use moveTo, instead of LineTo for the next section)
- [x] Consider also ignoring Infinite values (use isFinite instead of !isNaN)
