### PR TITLE
Improved interfacing with GtkD for GGPlotD.drawToSurface

### DIFF
--- a/source/ggplotd/ggplotd.d
+++ b/source/ggplotd/ggplotd.d
@@ -136,7 +136,7 @@ struct Margins
 /// GGPlotD contains the needed information to create a plot
 struct GGPlotD
 {
-    /// Draw the plot to a cairo surface
+    /// Draw the plot to a cairoD cairo surface.
     auto drawToSurface( ref cairo.Surface surface, int width, int height ) const
     {
         import std.range : empty, front;
@@ -238,7 +238,7 @@ struct GGPlotD
         import gtkdSurface = cairo.Surface; // cairo surface module in GtkD package.
 
         /**
-        Draw the plot to a cairo surface.
+        Draw the plot to a GtkD cairo surface.
 
         Convenience method when interfacing with GtkD. Type of surface parameter is from the GtkD package, which allows
         straightforward integration with GtkD applications.
@@ -254,7 +254,7 @@ struct GGPlotD
             cairo.Surface cairodSurface = new cairo.Surface(cast(cairod_surface_t*)surface.getSurfaceStruct());
             drawToSurface(cairodSurface, width, height);
 
-            return new gtkdSurface.Surface(cast(gtkd_surface_t*)cairodSurface);
+            return surface;
         }
     }
 

--- a/source/ggplotd/ggplotd.d
+++ b/source/ggplotd/ggplotd.d
@@ -136,7 +136,17 @@ struct Margins
 /// GGPlotD contains the needed information to create a plot
 struct GGPlotD
 {
-    /// Draw the plot to a cairoD cairo surface.
+    /**
+    Draw the plot to a cairoD cairo surface.
+
+    Params:
+        surface = Surface object of type cairo.Surface from cairoD library, on top of which this plot is drawn.
+        width = Width of the given surface.
+        height = Height of the given surface.
+
+    Returns:
+        Resulting surface of the same type as input surface, with this plot drawn on top of it.
+    */
     auto drawToSurface( ref cairo.Surface surface, int width, int height ) const
     {
         import std.range : empty, front;
@@ -240,8 +250,13 @@ struct GGPlotD
         /**
         Draw the plot to a GtkD cairo surface.
 
-        Convenience method when interfacing with GtkD. Type of surface parameter is from the GtkD package, which allows
-        straightforward integration with GtkD applications.
+        Params:
+            surface = Surface object of type cairo.Surface from GtkD library, on top of which this plot is drawn.
+            width = Width of the given surface.
+            height = Height of the given surface.
+
+        Returns:
+            Resulting surface of the same type as input surface, with this plot drawn on top of it.
         */
         auto drawToSurface( ref gtkdSurface.Surface surface, int width, int height ) const
         {


### PR DESCRIPTION
Version of `GGPlotD.drawToSurface` method is added, that takes the `surface` object of `Surface` type from GtkD package.

Added test proves that original `drawToSurface` method, and freshly added one produce the same result. If you'd like to have any other test added, please let me know.
