### PR TITLE
Enable OSX testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,19 @@ script: "./travis.sh"
 sudo: required 
 dist: trusty
 
+before_install:
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update          ; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libjpeg cairo gtk+3; fi
+
 matrix:
   include:
   - d: dmd
+    os: linux
     env:
       secure: CgAjTZgt34q5swaFpfif9XiWSaZMWGJYlufXIO/6oNsMnS29evf0TRfrRX+owj9KdyiEbq5VI0gFeU72qbeP+9yipLFwctw0wz5gh0ZThH/Nwy60Dy9b89S/tx8qZ5f+bDc780kopw90RUQtqTGBb/ZKy6XLMqmoJmPNFZO53ykAK2QyY3zmTZbJ7a4IsLyhl441ho6FrCw59O8c2bHDCPEbeC+p0SjCAJPIvoBMlZc85ADSH00HxWMK/Y5ybSHFL61gwTQV2gfQG0/+iOqyVo/BPa+L28YICJRQz8Kx9lraeB92or9P1vseTO5AmVOsekWqj8Kztq7ovUMogtGWG9igj2B61B8ZKatFtPBDST3vgZwfTD/rNQjk7S8QMY0F1O9/RfC50QQtykr4IGfZZUWvi2Y6syXqfTTF00ZRWuVG4jWy2sTm2peN4v2x4QbaEW5YiycF0MEnHHa2TSyx2RIR8dAcZAy45dIeRlEIYjY1VXvJl325xTR6uFrTWkic9eNmYCQc0Ajo0XscQ6odeqqF2vX5dSOxGHLZfjFKh8BqGcde/efg4qn1qNLcw2sdKpDplZnWyLpaiM8RsCmyPrgTfvoT2r+fGYSgQpnHjXigc11l36R7ulR1D4XhicbeFjoavn24Qk/9e/cMIVwHxxVGF4w4kDHZhbCFVe1ZFKE=
   - d: ldc
+    os: linux
+  - d: dmd
+    os: osx
+
+

--- a/dub.json
+++ b/dub.json
@@ -19,7 +19,7 @@
         {
             "name": "ggplotd-gtk",
             "dependencies": {
-                "gtk-d:gtkd": "~>3.2.2"
+                "gtk-d:gtkd": "~>3.3.0"
             },
             "versions": ["ggplotdGTK"]
         }

--- a/travis.sh
+++ b/travis.sh
@@ -11,7 +11,9 @@ function build_doc {
 set -e -o pipefail
 
 dub test --compiler=${DC}
-dub test -c ggplotd-gtk --compiler=${DC}
+if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then # gtkd broken on osx
+    dub test -c ggplotd-gtk --compiler=${DC}
+fi
 
 if [[ $TRAVIS_BRANCH == 'master' ]] ; then
     if [ ! -z "$GH_TOKEN" ]; then


### PR DESCRIPTION
ggplotd-gtk testing is currently disabled for OSX, due to a linker error
in gtkd: gtkd-developers/GtkD#162
