### PR TITLE
Mark some variables as gshared to avoid segfaults with GtkD.

### DIFF
--- a/source/ggplotd/gtk.d
+++ b/source/ggplotd/gtk.d
@@ -70,10 +70,10 @@ protected:
 
 	Timeout m_timeout;
 
-    cairod.Surface surface;
+    __gshared cairod.Surface surface;
 
-    int width = 470;
-    int height = 470;
+    __gshared int width = 470;
+    __gshared int height = 470;
 }
 
 import core.thread;
@@ -153,5 +153,5 @@ class GTKWindow
         Main.run();
     }
 
-    SurfaceArea sa;
+    __gshared SurfaceArea sa;
 }


### PR DESCRIPTION
Running the gtk version of ggplotd on Linux or OSX results in a segfault due to some threading issues.

I've marked some variables with `__gshared` to get things working again.

The issue was first reported here: https://github.com/gtkd-developers/GtkD/issues/173