### PR TITLE
Fix deprecations

### DIFF
--- a/source/ggplotd/colour.d
+++ b/source/ggplotd/colour.d
@@ -27,7 +27,7 @@ auto namedColour(in string name)
     try
     {
         colour = colorFromString(name).toColourSpace!RGB;
-    } catch {}
+    } catch (Throwable) {}
     return colour;
 }
 

--- a/source/ggplotd/stat.d
+++ b/source/ggplotd/stat.d
@@ -508,7 +508,8 @@ auto statDensity2D(AES)( AES aesRange )
     import std.array : array;
     import std.conv : to;
     import std.range : chain, front, iota, zip;
-    import std.typecons : Erase, tuple, Tuple;
+    import std.meta : Erase;
+    import std.typecons : tuple, Tuple;
     import ggplotd.aes : Aes, group, DefaultGroupFields;
     import ggplotd.algorithm : safeMin, safeMax;
     import ggplotd.range : mergeRange;


### PR DESCRIPTION
Discovered in https://github.com/dlang/phobos/pull/5584#issuecomment-313915537

- `Erase` is part of std.meta for a long time
- catch statement without an exception specification is deprecated
`catch(Throwable)` can be used to retain the old behavior