### PR TITLE
fix tests: order of AA elems is not determined

### DIFF
--- a/source/ggplotd/geom.d
+++ b/source/ggplotd/geom.d
@@ -446,10 +446,10 @@ unittest
 
     import std.range : empty;
 
-    assertEqual(gl.front.xStore.min(), 1.0);
-    assertEqual(gl.front.xStore.max(), 1.1);
+    assertHasValue([1.0, 2.0], gl.front.xStore.min());
+    assertHasValue([1.1, 3.0], gl.front.xStore.max());
     gl.popFront;
-    assertEqual(gl.front.xStore.max(), 3.0);
+    assertHasValue([1.1, 3.0], gl.front.xStore.max());
     gl.popFront;
     assert(gl.empty);
 }


### PR DESCRIPTION
This PR is needed for https://github.com/dlang/druntime/pull/2243

`DefaultValues.mergeRange(aes).group` returns `.values` of associative array, created by `groupBy`, order of it elements is not deremined.
`gl` contains two elements, `gl.front.xStore.min()` may return 1.0 for the first and 2.0 for the second, or 2.0 for the first, or 1.0 for the second.
Both results are correct.

Please create tag is this merged for auto-test passing.