### PR TITLE
Fix import in ggplotd/stat.d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
     os: linux
     env:
       secure: CgAjTZgt34q5swaFpfif9XiWSaZMWGJYlufXIO/6oNsMnS29evf0TRfrRX+owj9KdyiEbq5VI0gFeU72qbeP+9yipLFwctw0wz5gh0ZThH/Nwy60Dy9b89S/tx8qZ5f+bDc780kopw90RUQtqTGBb/ZKy6XLMqmoJmPNFZO53ykAK2QyY3zmTZbJ7a4IsLyhl441ho6FrCw59O8c2bHDCPEbeC+p0SjCAJPIvoBMlZc85ADSH00HxWMK/Y5ybSHFL61gwTQV2gfQG0/+iOqyVo/BPa+L28YICJRQz8Kx9lraeB92or9P1vseTO5AmVOsekWqj8Kztq7ovUMogtGWG9igj2B61B8ZKatFtPBDST3vgZwfTD/rNQjk7S8QMY0F1O9/RfC50QQtykr4IGfZZUWvi2Y6syXqfTTF00ZRWuVG4jWy2sTm2peN4v2x4QbaEW5YiycF0MEnHHa2TSyx2RIR8dAcZAy45dIeRlEIYjY1VXvJl325xTR6uFrTWkic9eNmYCQc0Ajo0XscQ6odeqqF2vX5dSOxGHLZfjFKh8BqGcde/efg4qn1qNLcw2sdKpDplZnWyLpaiM8RsCmyPrgTfvoT2r+fGYSgQpnHjXigc11l36R7ulR1D4XhicbeFjoavn24Qk/9e/cMIVwHxxVGF4w4kDHZhbCFVe1ZFKE=
-  - d: ldc
-    os: linux
   - d: dmd
     os: osx
 

--- a/source/ggplotd/stat.d
+++ b/source/ggplotd/stat.d
@@ -441,7 +441,7 @@ auto statDensity(AES)( AES aesRange )
         // Initialize kernel with normal distribution.
         import std.math : isFinite;
         import dstats.kerneldensity : scottBandwidth, KernelDensity;
-        import dstats.random : normalPDF;
+        import dstats.distrib : normalPDF;
         auto sigma = scottBandwidth(xs);
         if (!isFinite(sigma) || sigma <= 0)
             sigma = 0.5;
@@ -538,7 +538,7 @@ auto statDensity2D(AES)( AES aesRange )
         // Calculate the kernel width (using scott thing in dstats)
         // Initialize kernel with normal distribution.
         import dstats.kerneldensity : scottBandwidth, KernelDensity;
-        import dstats.random : normalPDF;
+        import dstats.distrib : normalPDF;
         auto sigmaX = scottBandwidth(xs);
         if (!isFinite(sigmaX) || sigmaX <= 0)
             sigmaX = 1e-5;


### PR DESCRIPTION
This is currently blocking [1]. A few explanations: due to a compiler bug, privately imported symbols would be visible from other modules if they were selectively imported. As you can see, the module `dstats.random` does not define the symbol `normalPDF` [2], however it does import `dstats.distrib` which does define it [4].

After merging this, please push a new tag so that buildkite cand use the latest version of ggplotd.

Thanks!

[1] https://github.com/dlang/dmd/pull/9393
[2] https://github.com/DlangScience/dstats/blob/master/source/dstats/random.d
[3] https://github.com/DlangScience/dstats/blob/master/source/dstats/random.d#L120
[4] https://github.com/DlangScience/dstats/blob/master/source/dstats/distrib.d#L901