### PR TITLE
Inhibit some warnings and deprecations

### DIFF
--- a/source/ggplotd/colourspace.d
+++ b/source/ggplotd/colourspace.d
@@ -33,15 +33,15 @@ cairo.RGBA toCairoRGBA(C)( in C from )
 {
     auto rgb = toColourSpace!(RGBA,C)( from );
     return cairo.RGBA(
-        rgb.r, 
-        rgb.g, 
-        rgb.b, 
-        rgb.a 
+        rgb.r,
+        rgb.g,
+        rgb.b,
+        rgb.a
     );
 }
 
 /// Convert from Cairo colour to specified type (template)
-C fromCairoRGBA(C)( in cairo.RGBA crgb ) 
+C fromCairoRGBA(C)( in cairo.RGBA crgb )
 {
     auto rgba = RGBA( crgb.red, crgb.green, crgb.blue, crgb.alpha );
     return toColourSpace!C( rgba );
@@ -65,6 +65,10 @@ auto toTuple(T : XYZ)( T colour )
 auto toTuple(T)( T colour )
 {
     import std.typecons : Tuple;
-    return Tuple!(double, double, double)( colour.r, colour.g, colour.b );
+    import std.typecons : Nullable;
+    import std.traits : isInstanceOf;
+    static if (isInstanceOf!(Nullable, T))
+        return Tuple!(double, double, double)( colour.get().r, colour.get().g, colour.get().b );
+    else
+        return Tuple!(double, double, double)( colour.r, colour.g, colour.b );
 }
-

--- a/source/ggplotd/guide.d
+++ b/source/ggplotd/guide.d
@@ -14,7 +14,7 @@ private struct DiscreteStoreWithOffset
     bool put(in DiscreteStoreWithOffset ds)
     {
         bool added = false;
-        foreach(el, offset1, offset2; ds.data) 
+        foreach(el, offset1, offset2; ds.data)
         {
             if (this.put(el, offset1))
                 added = true;
@@ -112,7 +112,7 @@ package struct GuideStore(string type = "")
     import std.range : isInputRange;
     /// Put another GuideStore into the store
     void put(T)(in T gs)
-        if (is(T==GuideStore!(type))) 
+        if (is(T==GuideStore!(type)))
     {
         _store.put(gs._store);
 
@@ -151,7 +151,7 @@ package struct GuideStore(string type = "")
                 static if (!isColour!T) {
                     static if (is(T==string)) {
                         auto col = namedColour(value);
-                        if (col.isNull) 
+                        if (col.isNull)
                         {
                             _store.put(value, offset);
                         }
@@ -197,7 +197,7 @@ package struct GuideStore(string type = "")
     {
         import std.conv : to;
         double[string] hash;
-        foreach(k, v; _store.store) 
+        foreach(k, v; _store.store)
         {
             hash[k] = v.to!double;
         }
@@ -311,7 +311,7 @@ unittest
     gs3.put(cst_gs());
     assertEqual(gs3.store.walkLength, 3);
     assertEqual(gs3.store.array, ["a","b","c"]);
- 
+
 }
 
 unittest
@@ -395,7 +395,7 @@ struct GuideToColourFunction
                 static if (is(T==string)) {
                     auto col = namedColour(value);
                     if (!col.isNull)
-                        return RGBA(col.r, col.g, col.b, 1);
+                        return RGBA(col.get().r, col.get().g, col.get().b, 1);
                     else
                         return stringConvert(value);
                 } else {

--- a/source/ggplotd/scale.d
+++ b/source/ggplotd/scale.d
@@ -8,14 +8,14 @@ version (unittest)
     import dunit.toolkit;
 }
 
-alias ScaleType = 
+alias ScaleType =
     cairo.Context delegate(cairo.Context context, in Bounds bounds,
     double width, double height);
 
 /// Scale context by plot boundaries
 ScaleType scale()
 {
-    return (cairo.Context context, in Bounds bounds, 
+    return (cairo.Context context, in Bounds bounds,
         double pixelWidth, double pixelHeight) {
         context.translate(0, pixelHeight);
         context.scale(pixelWidth / bounds.width, -pixelHeight / bounds.height);
@@ -64,8 +64,8 @@ unittest
     assertEqual(sf.scale(10.0), 1);
 }
 
-/// 
-void applyScaleFunction(F, X, Y, Col, Size)(in F func, 
+///
+void applyScaleFunction(F, X, Y, Col, Size)(in F func,
     ref X x, ref Y y, ref Col col, ref Size size)
 {
     if (func.field == "x")
@@ -91,23 +91,23 @@ auto applyScale(B, XF, XStore, YF, YStore)(ref B bounds,
     if (!xf.scaleFunction.isNull)
     {
         // xmax won't be included in the iota so use that to initialize
-        xmax = xf.scaleFunction(xmax);
-        xmin = xf.scaleFunction(xmax);
+        xmax = xf.scaleFunction.get()(xmax);
+        xmin = xf.scaleFunction.get()(xmax);
         foreach(x; iota(xmin, xmax, (xmax-xmin)/100.0))
         {
-            xmin = safeMin(xmin, xf.scaleFunction(x));
-            xmax = safeMax(xmax, xf.scaleFunction(x));
+            xmin = safeMin(xmin, xf.scaleFunction.get()(x));
+            xmax = safeMax(xmax, xf.scaleFunction.get()(x));
         }
     }
     if (!yf.scaleFunction.isNull)
     {
         // ymax won't be included in the iota so use that to initialize
-        ymax = yf.scaleFunction(ymax);
-        ymin = yf.scaleFunction(ymax);
+        ymax = yf.scaleFunction.get()(ymax);
+        ymin = yf.scaleFunction.get()(ymax);
         foreach(y; iota(ymin, ymax, (ymax-ymin)/100.0))
         {
-            ymin = safeMin(ymin, yf.scaleFunction(y));
-            ymax = safeMax(ymax, yf.scaleFunction(y));
+            ymin = safeMin(ymin, yf.scaleFunction.get()(y));
+            ymax = safeMax(ymax, yf.scaleFunction.get()(y));
         }
     }
 

--- a/source/ggplotd/theme.d
+++ b/source/ggplotd/theme.d
@@ -31,10 +31,7 @@ ThemeFunction background( string colour )
     import ggplotd.colour : namedColour;
     auto col = namedColour(colour);
     assert(!col.isNull, "Unknown named colour");
-    return delegate(Theme t) { t.backgroundColour = 
-            RGBA(col.r, col.g, col.b, 1); 
+    return delegate(Theme t) { t.backgroundColour =
+        RGBA(col.get().r, col.get().g, col.get().b, 1);
         return t; };
 }
-
-
-


### PR DESCRIPTION
- Use explicit `Nullable.get()` that will be required from 2.096
- Qualify some parameters with `return`
- Remove trailing whitespace. My editor did that for me. Hope that's alright.