### PR TITLE
Import 'std.meta' before inspecting it

### DIFF
--- a/source/ggplotd/meta.d
+++ b/source/ggplotd/meta.d
@@ -1,11 +1,11 @@
 module ggplotd.meta;
 
 import std.traits;
+static import std.meta;
 
 /// 
 static if (__traits(hasMember, std.meta, "ApplyLeft"))
 {
-    static import std.meta;
     alias ApplyLeft = std.meta.ApplyLeft;
 } else { // Compatibility with older versions
     template ApplyLeft(alias Template, args...)


### PR DESCRIPTION
Currently `std.meta` is visible due to a [DMD bug](https://github.com/dlang/dmd/pull/12215)